### PR TITLE
Fix for latest iTerm AppleScript API

### DIFF
--- a/tab.fish
+++ b/tab.fish
@@ -51,7 +51,6 @@ function tab -d 'Open the current directory (or any other directory) in a new ta
           end tell
         end tell
       end tell
-      end tell
     "; or osascript 2>/dev/null -e "
       tell application \"iTerm\"
         tell current window

--- a/tab.fish
+++ b/tab.fish
@@ -44,18 +44,19 @@ function tab -d 'Open the current directory (or any other directory) in a new ta
     end
     osascript 2>/dev/null -e "
       tell application \"iTerm\"
-        tell current window
-      		set newTab to (create tab with profile \"$profile\")
-      		tell current session of newTab
-      			write text \"cd \\\"$cdto\\\"$cmd\"
-      		end tell
-      	end tell
-      end tell
-    "; or osascript 2>/dev/null -e "
-      tell application \"iTerm\"
         tell current terminal
           launch session \"$profile\"
           tell the last session
+            write text \"cd \\\"$cdto\\\"$cmd\"
+          end tell
+        end tell
+      end tell
+      end tell
+    "; or osascript 2>/dev/null -e "
+      tell application \"iTerm\"
+        tell current window
+          set newTab to (create tab with profile \"$profile\")
+          tell current session of newTab
             write text \"cd \\\"$cdto\\\"$cmd\"
           end tell
         end tell

--- a/tab.fish
+++ b/tab.fish
@@ -44,12 +44,12 @@ function tab -d 'Open the current directory (or any other directory) in a new ta
     end
     osascript 2>/dev/null -e "
       tell application \"iTerm\"
-        tell current terminal
-          launch session \"$profile\"
-          tell the last session
-            write text \"cd \\\"$cdto\\\"$cmd\"
-          end tell
-        end tell
+        tell current window
+      		set newTab to (create tab with profile \"$profile\")
+      		tell current session of newTab
+      			write text \"cd \\\"$cdto\\\"$cmd\"
+      		end tell
+      	end tell
       end tell
     "
 

--- a/tab.fish
+++ b/tab.fish
@@ -51,6 +51,15 @@ function tab -d 'Open the current directory (or any other directory) in a new ta
       		end tell
       	end tell
       end tell
+    "; or osascript 2>/dev/null -e "
+      tell application \"iTerm\"
+        tell current terminal
+          launch session \"$profile\"
+          tell the last session
+            write text \"cd \\\"$cdto\\\"$cmd\"
+          end tell
+        end tell
+      end tell
     "
 
   case 'Apple_Terminal'


### PR DESCRIPTION
Plugin should now work for versions of iTerm > 2.9.20150414.

This should fix #2.
