### PR TITLE
Add xfce4-terminal capability

### DIFF
--- a/functions/tab.fish
+++ b/functions/tab.fish
@@ -129,7 +129,7 @@ function __tab.term_program
       else if [ "$VTE_VERSION" -ge 3803 -o "$COLORTERM" = "gnome-terminal" ]
         echo gnome_terminal
       else if [ "$COLORTERM" = "xfce4-terminal" ]
-	echo xfce4_terminal
+        echo xfce4_terminal
       else if [ "$GUAKE_TAB_UUID" ]
         echo guake
       end

--- a/functions/tab.fish
+++ b/functions/tab.fish
@@ -99,6 +99,9 @@ Arguments:
     case "gnome_terminal"
       tab.gnome_terminal "$cdto" "$cmd"
 
+    case "xfce4_terminal"
+      tab.xfce4_terminal "$cdto" "$cmd"
+
     case "guake"
       tab.guake "$cdto" "$cmd"
 
@@ -125,6 +128,8 @@ function __tab.term_program
         end
       else if [ "$VTE_VERSION" -ge 3803 -o "$COLORTERM" = "gnome-terminal" ]
         echo gnome_terminal
+      else if [ "$COLORTERM" = "xfce4-terminal" ]
+	echo xfce4_terminal
       else if [ "$GUAKE_TAB_UUID" ]
         echo guake
       end

--- a/functions/tab.xfce4_terminal.fish
+++ b/functions/tab.xfce4_terminal.fish
@@ -1,3 +1,3 @@
-function tab.xfce4_terminal -a cdto
-  xfce4-terminal --tab --working-directory "$cdto"
+function tab.xfce4_terminal -a cdto cmd
+  xfce4-terminal --tab --working-directory "$cdto" -e "fish -c '$cmd; exec fish'"
 end

--- a/functions/tab.xfce4_terminal.fish
+++ b/functions/tab.xfce4_terminal.fish
@@ -1,0 +1,3 @@
+function tab.xfce4_terminal -a cdto
+  xfce4-terminal --tab --working-directory "$cdto"
+end


### PR DESCRIPTION
Tested on fish 2.4.0, on my rather clunky old Chromebook, running xfce4-terminal 0.6.3 (Xfce 4.10) under
DISTRIB_ID=Ubuntu
DISTRIB_RELEASE=14.04
DISTRIB_CODENAME=trusty
DISTRIB_DESCRIPTION="Ubuntu 14.04.4 LTS"
