### PR TITLE
Add Yakuake support

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 <br/>
 
-Open new iTerm, Apple Terminal, Konsole, Gnome Terminal and Guake tabs from the command line.
+Open new iTerm, Apple Terminal, Konsole, Yakuake, Gnome Terminal and Guake tabs from the command line.
 
 
 ## Install
@@ -34,7 +34,7 @@ $ tab [cmd]               Open a new tab and execute CMD
 $ tab [path] [cmd] ...    You can prolly guess
 $ tab [-s|--split]        Split the current tab instead of opening a new tab
 $ tab [-S|--split-horiz]  Split the current tab horizontally.
-                          (Splits are only supported in iTerm at this time)
+                          (Splits are only supported in iTerm and Yakuake at this time)
 ```
 
 

--- a/functions/tab.fish
+++ b/functions/tab.fish
@@ -91,6 +91,15 @@ Arguments:
     case "apple_terminal"
       tab.apple_terminal "$cdto" "$cmd"
 
+    case "yakuake"
+      if set -q splith
+        tab.yakuake.splith "$cdto" "$cmd"
+      else if set -q split
+        tab.yakuake.split "$cdto" "$cmd"
+      else
+        tab.yakuake "$cdto" "$cmd"
+      end
+
     case "konsole"
       tab.konsole "$cdto" "$cmd"
 
@@ -124,8 +133,11 @@ function __tab.term_program
 
     case "*"
       if [ "$KONSOLE_PROFILE_NAME" -o "$KONSOLE_DBUS_SERVICE" -o "$KONSOLE_DBUS_SESSION" -o "$KONSOLE_DBUS_WINDOW" ]
+        set is_yakuake (qdbus $KONSOLE_DBUS_SERVICE | grep yakuake)
         if [ "$KATE_PID" ]
           echo kate
+        else if test -n "$is_yakuake"
+          echo yakuake
         else
           echo konsole
         end

--- a/functions/tab.yakuake.fish
+++ b/functions/tab.yakuake.fish
@@ -1,0 +1,11 @@
+function tab.yakuake -a cdto cmd
+  qdbus org.kde.yakuake /yakuake/sessions addSession
+
+  if test -n "$cdto"
+    qdbus org.kde.yakuake /yakuake/sessions runCommand "cd $cdto"
+  end
+
+  if test -n "$cmd"
+    qdbus org.kde.yakuake /yakuake/sessions runCommand "$cmd"
+  end
+end

--- a/functions/tab.yakuake.split.fish
+++ b/functions/tab.yakuake.split.fish
@@ -1,0 +1,11 @@
+function tab.yakuake.split -a cdto cmd
+  qdbus org.kde.yakuake /yakuake/sessions splitSessionLeftRight $KONSOLE_DBUS_SESSION
+
+  if test -n "$cdto"
+    qdbus $KONSOLE_DBUS_SERVICE $KONSOLE_DBUS_SESSION runCommand "cd $cdto"
+  end
+   
+  if test -n "$cmd"
+    qdbus $KONSOLE_DBUS_SERVICE $KONSOLE_DBUS_SESSION runCommand "$cmd"
+  end   
+end

--- a/functions/tab.yakuake.splith.fish
+++ b/functions/tab.yakuake.splith.fish
@@ -1,0 +1,11 @@
+function tab.yakuake.splith -a cdto cmd
+  qdbus org.kde.yakuake /yakuake/sessions splitSessionTopBottom $KONSOLE_DBUS_SESSION
+
+  if test -n "$cdto"
+    qdbus $KONSOLE_DBUS_SERVICE $KONSOLE_DBUS_SESSION runCommand "cd $cdto"
+  end
+   
+  if test -n "$cmd"
+    qdbus $KONSOLE_DBUS_SERVICE $KONSOLE_DBUS_SESSION runCommand "$cmd"
+  end
+end


### PR DESCRIPTION
Hello,
I added Yakuake terminal support. The splitting features may not properly work on some situations because `$KONSOLE_DBUS_SESSION` variable is not giving consistent results on my system or I may be missing something while using qdbus. But overall tab command with/without arguments works.